### PR TITLE
Collapse duplicate moveShape mutations server-side.

### DIFF
--- a/backend/decode.ts
+++ b/backend/decode.ts
@@ -1,11 +1,10 @@
 import * as t from 'io-ts';
 import { isLeft, Either } from 'fp-ts/lib/Either';
 import { failure } from 'io-ts/lib/PathReporter'
-import {UserError} from './user_error';
 
 export function must<T>(result: Either<t.ValidationError[], T>): T {
   if (isLeft(result)) {
-    throw new UserError(failure(result.left).join('\n'));
+    throw new Error(failure(result.left).join('\n'));
   }
   return result.right;
 };

--- a/backend/user_error.ts
+++ b/backend/user_error.ts
@@ -1,5 +1,0 @@
-export class UserError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
-}


### PR DESCRIPTION
This is suprisingly more sublte than it at first seems like it would be.