### PR TITLE
Collapse mutations a different way.

### DIFF
--- a/backend/rds.ts
+++ b/backend/rds.ts
@@ -154,7 +154,7 @@ async function executeStatementInDatabase(
       name,
       value,
     }));
-  console.log("Executing", database, sql, JSON.stringify(params, null, ''));
+  console.log("Executing", database, sql, JSON.stringify(params, null, ""));
   const command = new ExecuteStatementCommand({
     database: database ?? "",
     resourceArn,

--- a/pages/api/replicache-pull.ts
+++ b/pages/api/replicache-pull.ts
@@ -6,7 +6,7 @@ import { getCookieVersion, getLastMutationID } from "../../backend/data";
 import { must } from "../../backend/decode";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  console.log(`Processing pull`, JSON.stringify(req.body, null, ''));
+  console.log(`Processing pull`, JSON.stringify(req.body, null, ""));
 
   const pull = must(pullRequest.decode(req.body));
   let cookie = pull.baseStateID === "" ? 0 : parseInt(pull.baseStateID);
@@ -24,8 +24,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       getCookieVersion(executor),
     ]);
   });
-  console.log('lastMutationID: ', lastMutationID);
-  console.log('Read all objects in', Date.now() - t0);
+  console.log("lastMutationID: ", lastMutationID);
+  console.log("Read all objects in", Date.now() - t0);
 
   // Grump. Typescript seems to not understand that the argument to transact()
   // is guaranteed to have been called before transact() exits.
@@ -68,7 +68,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     }
   }
 
-  console.log(`Returning`, JSON.stringify(resp, null, ''));
+  console.log(`Returning`, JSON.stringify(resp, null, ""));
   res.json(resp);
   res.end();
 };


### PR DESCRIPTION
When we drag an object, we get a pattern of mutations at server-side like:

setCursor,moveShape,setCursor,moveShape,etc.

Because of this, our collapsing logic was failing to collapse because
it just looked for strings of consecutive mutations of same type.

We can't just collapse all events of the same type in the same push
because that could change the behavior of intervening mutations.

Instead, we use the same trick the client does - caching the accessed
data in memory.

This also had a side-effect of allowing us to parallelize writes to
MySQL (at the cost of having to keep the tx open for lenght of push).