### PR TITLE
refactor: Move to heroku and pusher.js

### DIFF
--- a/backend/data.ts
+++ b/backend/data.ts
@@ -36,10 +36,6 @@ export async function createSchemaVersion1(executor: Executor) {
       lastmodified timestamp(6) not null
       )`);
 
-  await executor(`alter publication supabase_realtime add table space`);
-  await executor(`alter publication supabase_realtime set 
-      (publish = 'insert, update, delete');`);
-
   await executor(`create table client (
         id text primary key not null,
         lastmutationid integer not null,

--- a/backend/pg.ts
+++ b/backend/pg.ts
@@ -6,6 +6,9 @@ const pool = new Pool(
   process.env.DATABASE_URL
     ? {
         connectionString: process.env.DATABASE_URL,
+        ssl: {
+          rejectUnauthorized: false,
+        },
       }
     : undefined
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,21 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "cubic-hermite": "^1.0.0",
+        "nanoid": "^3.3.1",
         "next": "^11.0.1",
         "pg": "^8.7.3",
         "pusher": "^4.0.2",
         "pusher-js": "^7.0.3",
         "react": "17.0.2",
+        "react-bootstrap": "^2.3.1",
         "react-dom": "17.0.2",
+        "react-draggable": "^4.4.5",
+        "react-hotkeys": "^2.0.0",
         "replicache": "10.0.0",
-        "replicache-react": "^2.6.0"
+        "replicache-react": "^2.6.0",
+        "todomvc-app-css": "^2.4.2",
+        "zod": "^3.13.4"
       },
       "devDependencies": {
         "@supabase/realtime-js": "^1.3.6",
@@ -26,17 +33,9 @@
         "@types/pg": "^8.6.4",
         "@types/react": "^17.0.11",
         "chai": "^4.3.6",
-        "classnames": "^2.3.1",
-        "cubic-hermite": "^1.0.0",
         "mocha": "^9.2.1",
-        "nanoid": "^3.3.1",
         "prettier": "^2.2.1",
-        "react-bootstrap": "^2.3.1",
-        "react-draggable": "^4.4.5",
-        "react-hotkeys": "^2.0.0",
-        "todomvc-app-css": "^2.4.2",
-        "typescript": "^4.1.5",
-        "zod": "^3.13.4"
+        "typescript": "^4.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -217,7 +216,6 @@
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -227,7 +225,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.2.tgz",
       "integrity": "sha512-amXY11ImpokvkTMeKRHjsSsG7v1yzzs6yeqArCyBIk60J3Yhgxwx9Cah+Uu/804ATFwqzN22AXIo7SdtIaMP+g==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2"
       },
@@ -239,7 +236,6 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
       "integrity": "sha512-ZbjlEHcG+FQtpDPHd7i4FzNNvJf2enAwZfJbpM8CW7BhmOAbsHpZe3tsHwfQUrBuyrxWqPYp2x5UMnilWcY22A==",
-      "dev": true,
       "dependencies": {
         "dequal": "^2.0.2"
       },
@@ -251,7 +247,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.2.0.tgz",
       "integrity": "sha512-oIh2t3tG8drZtZ9SlaV5CY6wGsUViHk8ZajjhcI+74IQHyWy+AnxDv8rJR5wVgsgcgrPBUvGNkC1AEdcGNPaLQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.16",
         "@popperjs/core": "^2.10.1",
@@ -272,7 +267,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
       "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -360,14 +354,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "node_modules/@types/react": {
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
       "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -378,7 +370,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
       "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -386,14 +377,12 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=",
-      "dev": true
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "node_modules/@types/websocket": {
       "version": "1.0.5",
@@ -852,8 +841,7 @@
     "node_modules/classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -870,7 +858,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1073,14 +1060,12 @@
     "node_modules/csstype": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
-      "dev": true
+      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
     },
     "node_modules/cubic-hermite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
-      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU=",
-      "dev": true
+      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -1155,7 +1140,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
       "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1197,7 +1181,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -1776,7 +1759,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -3212,7 +3194,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
       "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "dev": true,
       "dependencies": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
@@ -3339,7 +3320,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.3.1.tgz",
       "integrity": "sha512-+k68LdaSS62Zc/1gr18NC9QpDk/wwhNk+90QgcTMYSA8BzlXC1G2ogWWrz2LFuP2FlmCtVjcr/UXw3mpdxVmWw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
@@ -3369,7 +3349,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
       "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3381,7 +3360,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3405,7 +3383,6 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
       "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
-      "dev": true,
       "dependencies": {
         "clsx": "^1.1.1",
         "prop-types": "^15.8.1"
@@ -3419,7 +3396,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3430,7 +3406,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
       "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
-      "dev": true,
       "dependencies": {
         "prop-types": "^15.6.1"
       },
@@ -3446,8 +3421,7 @@
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
@@ -3461,7 +3435,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
       "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -3907,8 +3880,7 @@
     "node_modules/todomvc-app-css": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.2.tgz",
-      "integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg==",
-      "dev": true
+      "integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.0",
@@ -4025,7 +3997,6 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
       "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.6.3",
         "@types/react": ">=16.9.11",
@@ -4118,7 +4089,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -4361,7 +4331,6 @@
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.13.4.tgz",
       "integrity": "sha512-LZRucWt4j/ru5azOkJxCfpR87IyFDn8h2UODdqvXzZLb3K7bb9chUrUIGTy3BPsr8XnbQYfQ5Md5Hu2OYIo1mg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4508,14 +4477,12 @@
     "@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "dev": true
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@react-aria/ssr": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.2.tgz",
       "integrity": "sha512-amXY11ImpokvkTMeKRHjsSsG7v1yzzs6yeqArCyBIk60J3Yhgxwx9Cah+Uu/804ATFwqzN22AXIo7SdtIaMP+g==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.2"
       }
@@ -4524,7 +4491,6 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
       "integrity": "sha512-ZbjlEHcG+FQtpDPHd7i4FzNNvJf2enAwZfJbpM8CW7BhmOAbsHpZe3tsHwfQUrBuyrxWqPYp2x5UMnilWcY22A==",
-      "dev": true,
       "requires": {
         "dequal": "^2.0.2"
       }
@@ -4533,7 +4499,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.2.0.tgz",
       "integrity": "sha512-oIh2t3tG8drZtZ9SlaV5CY6wGsUViHk8ZajjhcI+74IQHyWy+AnxDv8rJR5wVgsgcgrPBUvGNkC1AEdcGNPaLQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.16",
         "@popperjs/core": "^2.10.1",
@@ -4550,7 +4515,6 @@
           "version": "7.17.9",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
           "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -4637,14 +4601,12 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
       "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4655,7 +4617,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
       "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -4663,14 +4624,12 @@
     "@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=",
-      "dev": true
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/websocket": {
       "version": "1.0.5",
@@ -5034,8 +4993,7 @@
     "classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -5051,8 +5009,7 @@
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -5238,14 +5195,12 @@
     "csstype": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
-      "dev": true
+      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
     },
     "cubic-hermite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
-      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU=",
-      "dev": true
+      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
     },
     "d": {
       "version": "1.0.1",
@@ -5301,8 +5256,7 @@
     "dequal": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "dev": true
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "des.js": {
       "version": "1.0.1",
@@ -5340,7 +5294,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -5783,7 +5736,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -6845,7 +6797,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
       "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "dev": true,
       "requires": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
@@ -6955,7 +6906,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.3.1.tgz",
       "integrity": "sha512-+k68LdaSS62Zc/1gr18NC9QpDk/wwhNk+90QgcTMYSA8BzlXC1G2ogWWrz2LFuP2FlmCtVjcr/UXw3mpdxVmWw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
@@ -6975,7 +6925,6 @@
           "version": "7.17.9",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
           "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -6984,7 +6933,6 @@
           "version": "15.8.1",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
           "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -7007,7 +6955,6 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
       "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
-      "dev": true,
       "requires": {
         "clsx": "^1.1.1",
         "prop-types": "^15.8.1"
@@ -7017,7 +6964,6 @@
           "version": "15.8.1",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
           "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -7030,7 +6976,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
       "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
-      "dev": true,
       "requires": {
         "prop-types": "^15.6.1"
       }
@@ -7043,8 +6988,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -7055,7 +6999,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
       "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -7398,8 +7341,7 @@
     "todomvc-app-css": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.2.tgz",
-      "integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg==",
-      "dev": true
+      "integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg=="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -7488,7 +7430,6 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
       "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.3",
         "@types/react": ">=16.9.11",
@@ -7566,7 +7507,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -7750,8 +7690,7 @@
     "zod": {
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.13.4.tgz",
-      "integrity": "sha512-LZRucWt4j/ru5azOkJxCfpR87IyFDn8h2UODdqvXzZLb3K7bb9chUrUIGTy3BPsr8XnbQYfQ5Md5Hu2OYIo1mg==",
-      "dev": true
+      "integrity": "sha512-LZRucWt4j/ru5azOkJxCfpR87IyFDn8h2UODdqvXzZLb3K7bb9chUrUIGTy3BPsr8XnbQYfQ5Md5Hu2OYIo1mg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs",
+  "name": "replidraw",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs",
+      "name": "replidraw",
       "version": "0.1.0",
       "dependencies": {
         "cubic-hermite": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'backend/**/*.test.ts'"
   },
   "dependencies": {
+    "cubic-hermite": "^1.0.0",
+    "nanoid": "^3.3.1",
     "next": "^11.0.1",
     "pg": "^8.7.3",
     "pusher": "^4.0.2",
@@ -17,7 +19,12 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "replicache": "10.0.0",
-    "replicache-react": "^2.6.0"
+    "replicache-react": "^2.6.0",
+    "react-bootstrap": "^2.3.1",
+    "react-draggable": "^4.4.5",
+    "react-hotkeys": "^2.0.0",
+    "todomvc-app-css": "^2.4.2",
+    "zod": "^3.13.4"
   },
   "devDependencies": {
     "@supabase/realtime-js": "^1.3.6",
@@ -28,16 +35,8 @@
     "@types/pg": "^8.6.4",
     "@types/react": "^17.0.11",
     "chai": "^4.3.6",
-    "classnames": "^2.3.1",
-    "cubic-hermite": "^1.0.0",
     "mocha": "^9.2.1",
-    "nanoid": "^3.3.1",
     "prettier": "^2.2.1",
-    "react-bootstrap": "^2.3.1",
-    "react-draggable": "^4.4.5",
-    "react-hotkeys": "^2.0.0",
-    "todomvc-app-css": "^2.4.2",
-    "typescript": "^4.1.5",
-    "zod": "^3.13.4"
+    "typescript": "^4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs",
+  "name": "replidraw",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "zod": "^3.13.4"
   },
   "devDependencies": {
-    "@supabase/realtime-js": "^1.3.6",
-    "@supabase/supabase-js": "^1.31.1",
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^14.14.37",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p $PORT",
     "format": "prettier --write './**/*.{js,jsx,json,ts,tsx,html,css,md}'",
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'backend/**/*.test.ts'"
   },

--- a/pages/api/replicache-pull.ts
+++ b/pages/api/replicache-pull.ts
@@ -17,14 +17,13 @@ const pullRequest = z.object({
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   console.log(`Processing pull`, JSON.stringify(req.body, null, ""));
 
+  const t0 = Date.now();
   const spaceID = req.query["spaceID"].toString();
   const pull = pullRequest.parse(req.body);
   let requestCookie = pull.cookie;
 
   console.log("spaceID", spaceID);
   console.log("clientID", pull.clientID);
-
-  const t0 = Date.now();
 
   const [entries, lastMutationID, responseCookie] = await transact(
     async (executor) => {
@@ -63,7 +62,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     }
   }
 
-  console.log(`Returning`, JSON.stringify(resp, null, ""));
   res.json(resp);
   res.end();
+  console.log("Processing pull took", Date.now() - t0);
 };

--- a/pages/api/replicache-push.ts
+++ b/pages/api/replicache-push.ts
@@ -29,10 +29,11 @@ const pushRequestSchema = z.object({
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   console.log("Processing push", JSON.stringify(req.body, null, ""));
 
+  const t0 = Date.now();
+
   const spaceID = req.query["spaceID"].toString();
   const push = pushRequestSchema.parse(req.body);
 
-  const t0 = Date.now();
   await transact(async (executor) => {
     await createDatabase(executor);
 
@@ -99,7 +100,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     appId: "1157097",
     key: "d9088b47d2371d532c4c",
     secret: "64204dab73c42e17afc3",
-    cluster: "us3",
+    cluster: "mt1",
     useTLS: true,
   });
 
@@ -110,4 +111,5 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   console.log("Sent poke in", Date.now() - t2);
 
   res.status(200).json({});
+  console.log("Processing push took", Date.now() - t0);
 };

--- a/pages/api/replicache-push.ts
+++ b/pages/api/replicache-push.ts
@@ -11,6 +11,7 @@ import { ReplicacheTransaction } from "../../backend/replicache-transaction";
 import { mutators } from "../../frontend/mutators";
 import { z } from "zod";
 import { jsonSchema } from "../../util/json";
+import Pusher from "pusher";
 
 // TODO: Either generate schema from mutator types, or vice versa, to tighten this.
 // See notes in bug: https://github.com/rocicorp/replidraw/issues/47
@@ -93,6 +94,20 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   });
 
   console.log("Processed all mutations in", Date.now() - t0);
+
+  const pusher = new Pusher({
+    appId: "1157097",
+    key: "d9088b47d2371d532c4c",
+    secret: "64204dab73c42e17afc3",
+    cluster: "us3",
+    useTLS: true,
+  });
+
+  const t2 = Date.now();
+  // We need to await here otherwise, Next.js will frequently kill the request
+  // and the poke won't get sent.
+  await pusher.trigger("default", "poke", {});
+  console.log("Sent poke in", Date.now() - t2);
 
   res.status(200).json({});
 };

--- a/pages/api/replicache-push.ts
+++ b/pages/api/replicache-push.ts
@@ -97,9 +97,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   console.log("Processed all mutations in", Date.now() - t0);
 
   const pusher = new Pusher({
-    appId: "1157097",
-    key: "d9088b47d2371d532c4c",
-    secret: "64204dab73c42e17afc3",
+    appId: "1407203",
+    key: "d56ed6dcf532b5fb344d",
+    secret: "12853972ceb8e1f63411",
     cluster: "mt1",
     useTLS: true,
   });

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -41,7 +41,7 @@ export default function Home() {
 
       Pusher.logToConsole = true;
       var pusher = new Pusher("d9088b47d2371d532c4c", {
-        cluster: "us3",
+        cluster: "mt1",
       });
       var channel = pusher.subscribe("default");
       channel.bind("poke", function (data: unknown) {

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -40,7 +40,7 @@ export default function Home() {
       };
 
       Pusher.logToConsole = true;
-      var pusher = new Pusher("d9088b47d2371d532c4c", {
+      var pusher = new Pusher("d56ed6dcf532b5fb344d", {
         cluster: "mt1",
       });
       var channel = pusher.subscribe("default");

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -6,7 +6,6 @@ import Pusher from "pusher-js";
 import { M, mutators } from "../../frontend/mutators";
 import { randUserInfo } from "../../frontend/client-state";
 import { randomShape } from "../../frontend/shape";
-import { createClient } from "@supabase/supabase-js";
 
 export default function Home() {
   const [rep, setRep] = useState<Replicache<M> | null>(null);
@@ -27,17 +26,6 @@ export default function Home() {
         name: docID,
         mutators,
       });
-
-      const supabase = createClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_KEY!
-      );
-      supabase
-        .from(`space:id=eq.${docID}`)
-        .on("*", () => {
-          r.pull();
-        })
-        .subscribe();
 
       const defaultUserInfo = randUserInfo();
       await r.mutate.initClientState({

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -20,7 +20,7 @@ export default function Home() {
       const [, , docID] = location.pathname.split("/");
       const r = new Replicache({
         // To get your own license key run `npx replicache get-license`. (It's free.)
-        licenseKey: "la5c53b6c73b144e9b3b7d888f537bf62", //process.env.NEXT_PUBLIC_REPLICACHE_LICENSE_KEY!,
+        licenseKey: process.env.NEXT_PUBLIC_REPLICACHE_LICENSE_KEY!,
         pushURL: `/api/replicache-push?spaceID=${docID}`,
         pullURL: `/api/replicache-pull?spaceID=${docID}`,
         name: docID,

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -20,7 +20,7 @@ export default function Home() {
       const [, , docID] = location.pathname.split("/");
       const r = new Replicache({
         // To get your own license key run `npx replicache get-license`. (It's free.)
-        licenseKey: process.env.NEXT_PUBLIC_REPLICACHE_LICENSE_KEY!,
+        licenseKey: "la5c53b6c73b144e9b3b7d888f537bf62", //process.env.NEXT_PUBLIC_REPLICACHE_LICENSE_KEY!,
         pushURL: `/api/replicache-push?spaceID=${docID}`,
         pullURL: `/api/replicache-pull?spaceID=${docID}`,
         name: docID,


### PR DESCRIPTION
Update to a new pusher.js app `replidraw-mt1` that is in the same aws location as heroku.

This still works on vercel which we can use for previews.